### PR TITLE
Using Java 11, and checking style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <version>1.1.1</version>
     <properties>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.project.info.reports.plugin>3.1.2</maven.project.info.reports.plugin>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
+                        <phase>process-sources</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
The current stack to use in CRW does not include Java 17 (issue https://github.com/rht-labs/enablement-framework/issues/110), if the developer executes maven command will fail.

This PR includes the following minor changes:

- Use Java 11 to build, test and package the application
- Enable checkstyle during the process-source phase, otherwise the check style is not executing during the test phase.
