### PR TITLE
⬆️ Update to Quarkus 2.13.5.Final ⬆️

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <maven.project.info.reports.plugin>3.3.0</maven.project.info.reports.plugin>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.version>2.13.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.13.5.Final</quarkus.platform.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <surefire.plugin.version>3.0.0-M7</surefire.plugin.version>


### PR DESCRIPTION
Related to [this GH Issue](https://github.com/rht-labs/tech-exercise/issues/245) in the technical exercises, this PR includes the upgrade to the latest minor version of Quarkus 2.13.X.
