### PR TITLE
🩺 Upgrade Quarkus so that it passes Image check 🩺

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <maven.project.info.reports.plugin>3.4.1</maven.project.info.reports.plugin>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.version>3.6.0</quarkus.platform.version>
+        <quarkus.platform.version>3.15.7</quarkus.platform.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <surefire.plugin.version>3.0.0-M9</surefire.plugin.version>
@@ -47,11 +47,11 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
+            <artifactId>quarkus-rest-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,6 +25,7 @@ quarkus.http.http2=true
 quarkus.http.port=8080
 quarkus.http.ssl-port=8443
 quarkus.http.ssl.certificate.key-store-file=keystore.jks
+quarkus.http.ssl.certificate.key-store-password=${KEYSTORE_PASSWORD:password}
 quarkus.http.host=0.0.0.0
 
 quarkus.native.additional-build-args=-H:ResourceConfigurationFiles=resources-config.json


### PR DESCRIPTION
Current version of the application has critical CVEs, so that we cannot demonstrate the behaviour of the Image Check step in the pipeline:

```bash
"violation": [
"Fixable CVE-2024-2700 (CVSS 7) (severity Important) found in component 'io.quarkus:quarkus-core' (version 3.6.0), resolved by version 3.8.4",
"Fixable CVE-2025-24970 (CVSS 7.5) (severity Important) found in component 'io.netty:netty-handler' (version 4.1.100.Final), resolved by version 4.1.118.Final",
"Fixable CVE-2025-55163 (CVSS 7.5) (severity Important) found in component 'io.netty:netty-codec-http2' (version 4.1.100.Final), resolved by version 4.1.124.Final"
],
```

Despite upgrading Quarkus to 3.8.4 is enough for the first, netty was not upgraded until this LTS version of Quarkus: 3.15.7. That's why we are upgrading until there. 

Also, There are two libraries that changed naming convention, so that I also upgraded.

*NOTE*: I'm *NOT* bumping the version of the pet-battle-api component on purpose so that this does not break all the enablement guides.