### PR TITLE
Fix/vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <maven.project.info.reports.plugin>3.4.1</maven.project.info.reports.plugin>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.version>3.6.0</quarkus.platform.version>
+        <quarkus.platform.version>3.20.6.1</quarkus.platform.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <surefire.plugin.version>3.0.0-M9</surefire.plugin.version>
@@ -35,6 +35,13 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.133.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
**Problem**

ACM image scan fails because of old version of quarkus and netty.

<img width="1101" height="641" alt="Screenshot 2026-06-03 at 15 26 43" src="https://github.com/user-attachments/assets/cb52e5e7-7112-4593-bad5-2be7d3ec6d1c" />

**Solution**

Modify quarkus platform version, including the specific version for netty.
